### PR TITLE
Feat/axis edit modals

### DIFF
--- a/src/components/Builder/BuilderApp.svelte
+++ b/src/components/Builder/BuilderApp.svelte
@@ -18,12 +18,7 @@
     type HighlightType,
     type SeriesType
   } from '../../lib/types';
-  import {
-    defaultAxisLabelFormatStrings,
-    PROJECT_NAME,
-    SCROLLY_MARK_PREFIX,
-    SCROLLY_OPENER_PREFIX
-  } from '../../lib/constants';
+  import { PROJECT_NAME, SCROLLY_MARK_PREFIX, SCROLLY_OPENER_PREFIX } from '../../lib/constants';
 
   import AnnotationEditForm from './edit-forms/AnnotationEditForm.svelte';
   import ArrowEditForm from './edit-forms/ArrowEditForm.svelte';
@@ -32,8 +27,7 @@
   import DataSourceEditForm from './edit-forms/DataSourceEditForm.svelte';
   import DataSetEditForm from './edit-forms/DataSetEditForm.svelte';
   import SeriesEditForm from './edit-forms/SeriesEditForm.svelte';
-  import FieldGroup from './edit-forms/FieldGroup.svelte';
-  import AxisPositionInput from './edit-forms/AxisPositionInput.svelte';
+  import AxisEditButton from './edit-forms/AxisEditButton.svelte';
 
   const prefixes = {
     'Scrolly mark': SCROLLY_MARK_PREFIX,
@@ -138,68 +132,8 @@
       {#if !xAxisDataType || !yAxisDataType}
         <p>At least one series must be defined before axis options can be set.</p>
       {:else}
-        <FieldGroup label="Formatting">
-          <label for="x-axis-format">x ({xAxisDataType}) format</label>
-          <input
-            id="x-axis-format"
-            type="text"
-            bind:value={visState.config.axes.x.format}
-            placeholder={`Default: ${defaultAxisLabelFormatStrings[xAxisDataType || ''] || ''}`}
-          />
-          <label for="x-axis-ticks">x labels (ticks)</label>
-          <input
-            id="x-axis-ticks"
-            type="text"
-            bind:value={visState.config.axes.x.ticks}
-            placeholder="e.g. 1980, 1985, 1990"
-          />
-          <label for="y-axis-format">y ({yAxisDataType}) format</label>
-          <input
-            id="y-axis-format"
-            type="text"
-            bind:value={visState.config.axes.y.format}
-            placeholder={`Default: ${defaultAxisLabelFormatStrings[yAxisDataType || ''] || ''}`}
-          />
-          <label for="y-axis-ticks">y labels (ticks)</label>
-          <input
-            id="y-axis-ticks"
-            type="text"
-            bind:value={visState.config.axes.y.ticks}
-            placeholder="e.g. 0, 50, 100"
-          />
-        </FieldGroup>
-        <small>
-          Formatting uses d3's formatting functions (<a href="https://d3js.org/d3-format#locale_format">numbers</a>,
-          <a href="https://d3js.org/d3-time-format#locale_format">dates</a>).
-        </small>
-        <FieldGroup label="Chart extent x-axis">
-          <AxisPositionInput
-            label="Min"
-            id="x-axis-domain-min"
-            bind:value={visState.config.axes.x.domain.min}
-            columnType={xAxisDataType}
-          />
-          <AxisPositionInput
-            label="Max"
-            id="x-axis-domain-max"
-            bind:value={visState.config.axes.x.domain.max}
-            columnType={xAxisDataType}
-          />
-        </FieldGroup>
-        <FieldGroup label="Chart extent y-axis">
-          <AxisPositionInput
-            label="Min"
-            id="y-axis-domain-min"
-            bind:value={visState.config.axes.y.domain.min}
-            columnType={yAxisDataType}
-          />
-          <AxisPositionInput
-            label="Max"
-            id="y-axis-domain-max"
-            bind:value={visState.config.axes.y.domain.max}
-            columnType={yAxisDataType}
-          />
-        </FieldGroup>
+        <AxisEditButton bind:axis={visState.config.axes.x} label="X" columnType={xAxisDataType} />
+        <AxisEditButton bind:axis={visState.config.axes.y} label="Y" columnType={yAxisDataType} />
       {/if}
     </fieldset>
     <ItemCollection

--- a/src/components/Builder/edit-forms/AxisEditButton.svelte
+++ b/src/components/Builder/edit-forms/AxisEditButton.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { AxisOptionsSchema } from '../../../lib/schemas';
+  import type { ColumnTypesType } from '../../../lib/types';
+  import { defaultAxisLabelFormatStrings } from '../../../lib/constants';
+  import FieldGroup from './FieldGroup.svelte';
+  import AxisPositionInput from './AxisPositionInput.svelte';
+  import type { InferOutput } from 'valibot';
+  import { Arrows, ArrowsVertical } from 'svelte-bootstrap-icons';
+  import ItemCollectionEditModal from '../ItemCollectionEditModal.svelte';
+
+  interface Props {
+    axis: InferOutput<typeof AxisOptionsSchema>;
+    label: string;
+    columnType: ColumnTypesType | undefined;
+  }
+
+  let { axis = $bindable(), label, columnType }: Props = $props();
+
+  let isEditing = $state(false);
+</script>
+
+<button class="axis-edit-button" onclick={() => (isEditing = true)}>
+  {#if label === 'X'}
+    <Arrows />
+  {:else if label === 'Y'}
+    <ArrowsVertical />
+  {/if}
+  {label} Axis ({columnType || 'undefined'})
+</button>
+
+{#if isEditing}
+  <ItemCollectionEditModal title="Edit {label} Axis" onClose={() => (isEditing = false)}>
+    <FieldGroup>
+      <label for="{label.toLowerCase()}-axis-ticks">Labels</label>
+      <input
+        id="{label.toLowerCase()}-axis-ticks"
+        type="text"
+        bind:value={axis.ticks}
+        placeholder="e.g. 1980, 1985, 1990"
+      />
+      <label for="{label.toLowerCase()}-axis-format">Format</label>
+      <input
+        id="{label.toLowerCase()}-axis-format"
+        type="text"
+        bind:value={axis.format}
+        placeholder={`Default: ${defaultAxisLabelFormatStrings[columnType || ''] || ''}`}
+      />
+    </FieldGroup>
+    <small>
+      Formatting uses d3's formatting functions (<a href="https://d3js.org/d3-format#locale_format">numbers</a>,
+      <a href="https://d3js.org/d3-time-format#locale_format">dates</a>).
+    </small>
+
+    <hr />
+
+    <FieldGroup label="Chart extent">
+      <AxisPositionInput
+        label="Min"
+        id="{label.toLowerCase()}-axis-domain-min"
+        bind:value={axis.domain.min}
+        columnType={columnType as ColumnTypesType}
+      />
+      <AxisPositionInput
+        label="Max"
+        id="{label.toLowerCase()}-axis-domain-max"
+        bind:value={axis.domain.max}
+        columnType={columnType as ColumnTypesType}
+      />
+    </FieldGroup>
+  </ItemCollectionEditModal>
+{/if}
+
+<style>
+  .axis-edit-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    width: 100%;
+    justify-content: flex-start;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/Builder/edit-forms/AxisEditButton.svelte
+++ b/src/components/Builder/edit-forms/AxisEditButton.svelte
@@ -45,6 +45,12 @@
         bind:value={axis.format}
         placeholder={`Default: ${defaultAxisLabelFormatStrings[columnType || ''] || ''}`}
       />
+      {#if label === 'X'}
+        <label for="x-axis-baseline">
+          <input id="x-axis-baseline" type="checkbox" bind:checked={axis.baseline} />
+          Show axis line
+        </label>
+      {/if}
     </FieldGroup>
     <small>
       Formatting uses d3's formatting functions (<a href="https://d3js.org/d3-format#locale_format">numbers</a>,

--- a/src/components/Builder/edit-forms/FieldGroup.svelte
+++ b/src/components/Builder/edit-forms/FieldGroup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  let { children, columns = 2, label } = $props();
+  let { children, columns = 2, label = '' } = $props();
 </script>
 
 {#if label}<span>{label}</span>{/if}

--- a/src/components/Visualisation.svelte
+++ b/src/components/Visualisation.svelte
@@ -198,7 +198,7 @@
           ticks={xTicks || Math.floor(chartWidth / 130)}
           format={formatLabelX}
           dy={14}
-          baseline={true}
+          baseline={visState.config.axes.x.baseline}
           tickMarks
         />
         <AxisY ticks={yTicks || 4} format={formatLabelY} />

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,7 +1,7 @@
 import { parse } from 'date-fns';
 import {
   array,
-  date,
+  boolean,
   enum_,
   intersect,
   literal,
@@ -14,9 +14,7 @@ import {
   record,
   string,
   transform,
-  tuple,
   union,
-  url,
   variant
 } from 'valibot';
 import { AnnotationAnchorType } from './types';
@@ -109,6 +107,7 @@ export const DataSourceSchema = object({
 export const AxisOptionsSchema = object({
   format: optional(string()),
   ticks: optional(string()),
+  baseline: optional(boolean(), true),
   domain: object({
     min: optional(nullable(AxisPositionSchema)),
     max: optional(nullable(AxisPositionSchema))


### PR DESCRIPTION
Ben wanted to add the baseline prop to the builder, and I figured we've got enough stuff to group the axes into their own thing now.

<img width="292" height="132" alt="image" src="https://github.com/user-attachments/assets/26cfcc78-224c-4bc0-a307-b53e577e0f1d" />

Added arrows because someone on the team had to ask which axis was which and like, that's fair.

<img width="510" height="465" alt="image" src="https://github.com/user-attachments/assets/e8d75155-b2cc-4ed7-b23f-fa2a553f8373" />

Turned them into a modal and added the baseline checkbox true by default