### PR TITLE
Add ability to use a CMID as the data source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "chart-builder",
-			"version": "0.0.6",
+			"version": "0.0.8",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19,6 +19,7 @@
 				"@abcnews/mount-utils": "^3.0.0",
 				"@abcnews/palette": "^1.0.1",
 				"@abcnews/svelte-scrollyteller": "^3.0.1",
+				"@abcnews/terminus-fetch": "^7.0.0",
 				"@types/d3-format": "^3.0.4",
 				"async": "^3.2.6",
 				"d3-scale": "^4.0.2",
@@ -256,6 +257,24 @@
 			"peerDependencies": {
 				"svelte": "^5.20.4"
 			}
+		},
+		"node_modules/@abcnews/terminus-fetch": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@abcnews/terminus-fetch/-/terminus-fetch-7.0.0.tgz",
+			"integrity": "sha512-8mXsd79cfcjg0kqHlxw8xUn0GGuyZQcSHwbxjGVOetA7XU7W+7ne3DTRWIsNrtqbB7CtUT7KswkQC4iuqI1eoA==",
+			"license": "MIT",
+			"dependencies": {
+				"@abcnews/env-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@abcnews/terminus-fetch/node_modules/@abcnews/env-utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@abcnews/env-utils/-/env-utils-3.1.0.tgz",
+			"integrity": "sha512-e2NuIYaK/3W9v4QI1ZWAcRdVMy0mvfQqMKbfcjeVAGc0xF0SnzSVqO0YJo+4pnn96/C3vLuSQErap4+yh6sfTQ==",
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@abcnews/mount-utils": "^3.0.0",
 		"@abcnews/palette": "^1.0.1",
 		"@abcnews/svelte-scrollyteller": "^3.0.1",
+		"@abcnews/terminus-fetch": "^7.0.0",
 		"@types/d3-format": "^3.0.4",
 		"async": "^3.2.6",
 		"d3-scale": "^4.0.2",

--- a/src/components/Builder/edit-forms/DataSetEditForm.svelte
+++ b/src/components/Builder/edit-forms/DataSetEditForm.svelte
@@ -4,6 +4,7 @@
   import FormActions from './FormActions.svelte';
   import { Loader } from '@abcnews/components-builder';
   import ItemCollectionEditModal from '../ItemCollectionEditModal.svelte';
+  import { fetchDataUrl } from '../../../lib/data-helpers';
 
   interface Props {
     set: (DataSetType & DeletableType) | undefined;
@@ -13,7 +14,7 @@
 
   let columns = $derived.by(async () => {
     if (set?.url) {
-      const raw = await fetch(set.url).then(res => res.text());
+      const raw = await fetchDataUrl(set.url);
       const csv = csvParse(raw);
       return csv.columns;
     }

--- a/src/components/Visualisation.svelte
+++ b/src/components/Visualisation.svelte
@@ -20,6 +20,7 @@
   } from '../lib/types';
 
   import {
+    fetchDataUrl,
     getAxisLabelFormatter,
     getDefaultPalette,
     getDomain,
@@ -38,13 +39,15 @@
 
   // TODO: Move fetched and parsed data to a central state object from state.svelte.ts
   // A state variable to store the raw data from each of the data sources defined in the config.
+  // Object key is the name given to the dataset in the builder UI
   const rawData: Record<string, string> = $state({});
 
   // Load these into state via an effect to avoid use of #await. If the config changes so a new data needs to be fetched
   // we don't want the UI to change to an awaiting state while it's loading.
   $effect(() => {
     visState.config.data.forEach(async ({ name, url }) => {
-      const raw = await fetch(url).then(res => res.text());
+      // TODO: It would make sense to cache these locally, but for now rely on HTTP caching
+      const raw = await fetchDataUrl(url);
       rawData[name] = raw;
     });
   });

--- a/src/lib/data-accessors.ts
+++ b/src/lib/data-accessors.ts
@@ -5,46 +5,39 @@ import { VisualisationSchema } from './schemas';
 import type { VisualisationType } from './types';
 import { diff } from 'deep-object-diff';
 
+const replace = (source: {}, target: {}, key: string) => {
+  if (source[key] === undefined) {
+    // Arrays need special handling.
+    // This is something to do with the way Svelte signals are implemented. If the key is deleted as if it's a regular
+    // object svelte attempts to access a non-existent key.
+    if (Array.isArray(target) && typeof +key === 'number' && +key === +key) {
+      target.splice(+key, 1);
+    } else {
+      delete target[key];
+    }
+  } else {
+    target[key] = source[key];
+  }
+};
+
+const apply = (diff: {}, source: {}, target: {}) => {
+  for (const key in diff) {
+    if (typeof diff[key] === 'object' && typeof target[key] !== 'undefined') {
+      apply(diff[key], source[key], target[key]);
+    } else {
+      replace(source, target, key);
+    }
+  }
+};
+
 export const loadMarkerConfig = (data: string | Record<string, unknown>) => {
   const obj = typeof data === 'string' ? decode(data) : data;
 
   // TODO: This is where to migrate old schemas if that's needed.
 
-  const apply = (diff: {}, source: {}, target: {}, path: string[] = []) => {
-    for (const key in diff) {
-      const replace = () => {
-        if (source[key] === undefined) {
-          if (Array.isArray(target) && typeof +key === 'number' && +key === +key) {
-            console.log(`Removing index ${+key} from target ${JSON.stringify(target)}`);
-            target.splice(+key, 1);
-          } else {
-            console.log(`Deleting "${typeof target[key] === 'object' ? JSON.stringify(target[key]) : target[key]}"`);
-            delete target[key];
-          }
-        } else {
-          console.log(
-            `Replacing "${target[key]}" with "${
-              typeof source[key] === 'object' ? JSON.stringify(source[key]) : source[key]
-            }"`
-          );
-          target[key] = source[key];
-        }
-      };
-      if (typeof diff[key] === 'object' && typeof target[key] !== 'undefined') {
-        apply(diff[key], source[key], target[key], [...path, key]);
-      } else {
-        replace();
-      }
-    }
-  };
-
   const result = safeParse(VisualisationSchema, obj);
   if (result.success) {
-    const configDiff = diff(visState.config, result.output);
-    console.log('APPLYING DIFF', configDiff);
-    apply(configDiff, result.output, visState.config);
-    console.log('UPDATE FINISHED');
-    // visState.config = result.output;
+    apply(diff(visState.config, result.output), result.output, visState.config);
   } else {
     console.error(result.issues);
   }

--- a/src/lib/data-helpers.ts
+++ b/src/lib/data-helpers.ts
@@ -3,8 +3,9 @@ import type { AxisOptionsType, ColumnDefinitionType, ColumnTypesType, SeriesType
 import { timeFormat } from 'd3-time-format';
 import { format } from 'd3-format';
 import { defaultAxisLabelFormatStrings } from './constants';
-import { extent } from 'd3-array';
 import { getOrdinalCategoricalPalette } from '@abcnews/palette';
+import { fetchOne } from '@abcnews/terminus-fetch';
+import { TIERS } from '@abcnews/env-utils';
 
 /**
  * This is a modified version of the d3 autotype function
@@ -160,4 +161,18 @@ export const parseManualTicks = (ticksString: string | undefined, dataType: Colu
 
 export const getDefaultPalette = (series: SeriesType[]) => {
   return getOrdinalCategoricalPalette(Math.min(5, Math.max(2, series.length)));
+};
+
+export const fetchDataUrl = async (urlOrId: string) => {
+  // If url is parsable as a CMID, get the URL from Terminus
+  if (urlOrId.match(/^[0-9]+$/)) {
+    const doc = await fetchOne({
+      id: urlOrId,
+      type: 'DownloadObject',
+      force: window.location.hostname.includes('aus.aunty.abc') ? TIERS.PREVIEW : undefined
+    });
+    // @ts-expect-error Until terminus-fetch gets better types, this will be an error
+    if (doc.downloadURL) urlOrId = doc.downloadURL;
+  }
+  return await fetch(urlOrId).then(res => res.text());
 };


### PR DESCRIPTION
Producers can use the DownloadObject's CMID instead of having to dig out the URL from the CAPI preview pane. This also means the data file itself can be replaced without needing to update the config with a new URL.
