### PR TITLE
Compute x axis tick width a bit better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "chart-builder",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "A project generated from aunty's svelte project template.",
 	"license": "MIT",
 	"private": true,

--- a/src/components/Visualisation.svelte
+++ b/src/components/Visualisation.svelte
@@ -162,8 +162,8 @@
   let customLayerCakeContext: CustomLayerCakeContextType = $derived({ showConstructionMarks });
 
   const xTicksComputed = $derived.by(() => {
-    const ESTIMATED_CHARACTER_WIDTH = 11;
-    const TICK_LABEL_GAP = 12;
+    const ESTIMATED_CHARACTER_WIDTH = 12;
+    const TICK_LABEL_GAP = 16;
 
     // Custom ticks provided, return directly
     if (xTicks) return xTicks;
@@ -226,13 +226,13 @@
       <Svg>
         <AxisX
           gridlines={false}
-          ticks={xTicks || Math.floor(chartWidth / 130)}
+          ticks={xTicksComputed}
           format={formatLabelX}
           dy={14}
           baseline={visState.config.axes.x.baseline}
           tickMarks
         />
-        <AxisY ticks={xTicksComputed} />
+        <AxisY ticks={yTicks || 4} format={formatLabelY} />
       </Svg>
       <Svg overflow="hidden">
         <Lines />

--- a/src/components/Visualisation.svelte
+++ b/src/components/Visualisation.svelte
@@ -161,6 +161,7 @@
 
   let customLayerCakeContext: CustomLayerCakeContextType = $derived({ showConstructionMarks });
 
+  /** Number of ticks to show on the x axis */
   const xTicksComputed = $derived.by(() => {
     const ESTIMATED_CHARACTER_WIDTH = 12;
     const TICK_LABEL_GAP = 16;

--- a/src/components/Visualisation.svelte
+++ b/src/components/Visualisation.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { LayerCake, Svg, Html } from 'layercake';
   import { Tween } from 'svelte/motion';
-  import { scaleOrdinal } from 'd3-scale';
+  import { scaleOrdinal, scaleTime, scaleLinear } from 'd3-scale';
   import { csvParse } from 'd3-dsv';
   import FontProvider from './FontProvider.svelte'; // TODO Swap out for @abcnews/components-storylab version
   import AxisX from './layercake-components/AxisX.svg.svelte';
@@ -160,6 +160,35 @@
   });
 
   let customLayerCakeContext: CustomLayerCakeContextType = $derived({ showConstructionMarks });
+
+  const xTicksComputed = $derived.by(() => {
+    const ESTIMATED_CHARACTER_WIDTH = 11;
+    const TICK_LABEL_GAP = 12;
+
+    // Custom ticks provided, return directly
+    if (xTicks) return xTicks;
+
+    // Fallback simple chartWidth / 130px calculation
+    if (!xDomain || xAxisDataType === 'string') return Math.floor(chartWidth / 130);
+
+    const tempScale = xAxisDataType === 'date'
+      ? scaleTime().domain(xDomain as unknown as Date[])
+      : scaleLinear().domain(xDomain as unknown as number[]);
+
+    // Generate some temporary ticks
+    const sampleTicks = tempScale.ticks(10);
+
+    // Count the (formatted) string length
+    const maxLabelLength = Math.max(
+      ...sampleTicks.map((t: Date | number) => {
+        const label = formatLabelX ? String(formatLabelX(t as never)) : String(t);
+        return label.length;
+      }),
+      1
+    );
+
+    return Math.floor(chartWidth / (maxLabelLength * ESTIMATED_CHARACTER_WIDTH + TICK_LABEL_GAP));
+  });
 </script>
 
 <FontProvider>
@@ -203,7 +232,7 @@
           baseline={visState.config.axes.x.baseline}
           tickMarks
         />
-        <AxisY ticks={yTicks || 4} format={formatLabelY} />
+        <AxisY ticks={xTicksComputed} />
       </Svg>
       <Svg overflow="hidden">
         <Lines />


### PR DESCRIPTION
Adds a xTicksComputed function which estimates the tick length if ticks are not provided. Not perfect, but provides a bit better functionality than what is currently there.

eg:


https://github.com/user-attachments/assets/34ab8a2b-5e06-48e5-9bf2-0a979f17efcf

